### PR TITLE
fix(open_api.cr)

### DIFF
--- a/src/open_api.cr
+++ b/src/open_api.cr
@@ -8,7 +8,7 @@ module OpenAPI
   end
 
   def self.from_json(json)
-    Document.from_json(yaml)
+    Document.from_json(json)
   end
 
   {% begin %}


### PR DESCRIPTION
fix typo from yaml to json for a .from_json method